### PR TITLE
Map name and plan from webhook

### DIFF
--- a/lib/pay/revenuecat/webhooks/initial_purchase.rb
+++ b/lib/pay/revenuecat/webhooks/initial_purchase.rb
@@ -11,6 +11,7 @@ module Pay
           )
 
           args = {
+            name: event["presented_offering_id"],
             plan: event["product_id"],
             processor_id: event["original_transaction_id"], # seems to be the closest thing I can find to a subscription id across all events
             current_period_start: Time.at(event["purchased_at_ms"].to_i / 1000),

--- a/test/pay/revenuecat/webhooks/initial_purchase_test.rb
+++ b/test/pay/revenuecat/webhooks/initial_purchase_test.rb
@@ -9,15 +9,28 @@ class Pay::Revenuecat::Webhooks::InitialPurchaseTest < ActiveSupport::TestCase
   # end
   test "sets payment processor to revenuecat" do
     assert_difference "Pay::Charge.count" do
-      Pay::Revenuecat::Webhooks::InitialPurchase.new.call(revenuecat_params["event"])
+      Pay::Revenuecat::Webhooks::InitialPurchase.new.call(
+        initial_purchase_params
+      )
     end
+
+    subscription = @pay_customer.reload.subscriptions.first
+
+    assert_equal(
+      initial_purchase_params["presented_offering_id"],
+      subscription.name
+    )
+    assert_equal(
+      initial_purchase_params["product_id"],
+      subscription.processor_plan
+    )
   end
 
   private
 
-  def revenuecat_params
+  def initial_purchase_params
     JSON.parse(
       file_fixture("initial_purchase.json").read
-    )
+    )["event"]
   end
 end


### PR DESCRIPTION
Without a better guide to go by I've mapped things like so:

name is the human readable name, which I am mapping to the offering. This isn't very human readable, we may be able to get a human readabe name from the api but aren't calling it yet.

processor_plan is the processor's plan id, in this case I am picking the product_id for the unique product behind the offering.

offering: https://www.revenuecat.com/docs/offerings/overview

Fixes #12 