### PR TITLE
WIP: Add store to data, test for metadata

### DIFF
--- a/lib/pay/revenuecat/webhooks/cancellation.rb
+++ b/lib/pay/revenuecat/webhooks/cancellation.rb
@@ -9,14 +9,20 @@ module Pay
             :revenuecat, event["original_transaction_id"]
           )
 
+          data = (pay_subscription.data || {}).merge(
+            {
+              cancel_reason: event["cancel_reason"]
+            }
+          )
+
           ends_at = Time.at(event["expiration_at_ms"].to_i / 1000)
 
-          pay_subscription.with_lock do # I added a lock here, donno why they didn't have one
+          pay_subscription.with_lock do
             pay_subscription.update!(
-              status: (ends_at.future? ? :active : :canceled), # TODO: hmm so this means we need to change it to cancelled on the day?
+              status: (ends_at.future? ? :active : :canceled),
               trial_ends_at: (ends_at if pay_subscription.trial_ends_at?),
-              ends_at: ends_at
-              # TODO: add cancellation reason? from https://www.revenuecat.com/docs/integrations/webhooks/event-types-and-fields#cancellation-and-expiration-reasons
+              ends_at: ends_at,
+              data: data
             )
           end
         end

--- a/lib/pay/revenuecat/webhooks/cancellation.rb
+++ b/lib/pay/revenuecat/webhooks/cancellation.rb
@@ -20,7 +20,6 @@ module Pay
           pay_subscription.with_lock do
             pay_subscription.update!(
               status: (ends_at.future? ? :active : :canceled),
-              trial_ends_at: (ends_at if pay_subscription.trial_ends_at?),
               ends_at: ends_at,
               data: data
             )

--- a/lib/pay/revenuecat/webhooks/expiration.rb
+++ b/lib/pay/revenuecat/webhooks/expiration.rb
@@ -9,13 +9,19 @@ module Pay
             :revenuecat, event["original_transaction_id"]
           )
 
+          data = (pay_subscription.data || {}).merge(
+            {
+              expiration_reason: event["expiration_reason"]
+            }
+          )
+
           ends_at = Time.at(event["expiration_at_ms"].to_i / 1000)
 
-          pay_subscription.with_lock do # I added a lock here, donno why they didn't have one
+          pay_subscription.with_lock do
             pay_subscription.update!(
               status: "canceled",
-              ends_at: ends_at
-              # TODO: add an expiration reason?
+              ends_at: ends_at,
+              data: data
             )
           end
         end

--- a/lib/pay/revenuecat/webhooks/initial_purchase.rb
+++ b/lib/pay/revenuecat/webhooks/initial_purchase.rb
@@ -24,7 +24,7 @@ module Pay
             metadata: event["metadata"],
             data: data,
             metered: false,
-            status: :active # TODO: set "on_trial", "active", "canceled"
+            status: :active
           }
 
           payment_processor = pay_customer.owner.payment_processor

--- a/lib/pay/revenuecat/webhooks/initial_purchase.rb
+++ b/lib/pay/revenuecat/webhooks/initial_purchase.rb
@@ -20,6 +20,7 @@ module Pay
             processor_id: event["original_transaction_id"], # seems to be the closest thing I can find to a subscription id across all events
             current_period_start: Time.at(event["purchased_at_ms"].to_i / 1000),
             current_period_end: Time.at(event["expiration_at_ms"].to_i / 1000),
+            ends_at: Time.at(event["expiration_at_ms"].to_i / 1000),
             metadata: event["metadata"],
             data: data,
             metered: false, # TODO: Handle metered billing

--- a/lib/pay/revenuecat/webhooks/initial_purchase.rb
+++ b/lib/pay/revenuecat/webhooks/initial_purchase.rb
@@ -10,6 +10,10 @@ module Pay
             processor_id: event["app_user_id"]
           )
 
+          data = {
+            store: event["store"]
+          }
+
           args = {
             name: event["presented_offering_id"],
             plan: event["product_id"],
@@ -17,6 +21,7 @@ module Pay
             current_period_start: Time.at(event["purchased_at_ms"].to_i / 1000),
             current_period_end: Time.at(event["expiration_at_ms"].to_i / 1000),
             metadata: event["metadata"],
+            data: data,
             metered: false, # TODO: Handle metered billing
             status: :active # TODO: set "on_trial", "active", "canceled"
             # application_fee_percent: nil,

--- a/lib/pay/revenuecat/webhooks/initial_purchase.rb
+++ b/lib/pay/revenuecat/webhooks/initial_purchase.rb
@@ -17,23 +17,18 @@ module Pay
           args = {
             name: event["presented_offering_id"],
             plan: event["product_id"],
-            processor_id: event["original_transaction_id"], # seems to be the closest thing I can find to a subscription id across all events
+            processor_id: event["original_transaction_id"],
             current_period_start: Time.at(event["purchased_at_ms"].to_i / 1000),
             current_period_end: Time.at(event["expiration_at_ms"].to_i / 1000),
             ends_at: Time.at(event["expiration_at_ms"].to_i / 1000),
             metadata: event["metadata"],
             data: data,
-            metered: false, # TODO: Handle metered billing
+            metered: false,
             status: :active # TODO: set "on_trial", "active", "canceled"
-            # application_fee_percent: nil,
-            # application_fee_percent: — stripe send this, though is null in all fixtures, revenue cat send:
-            #  "tax_percentage"=>0.1705,
-            #  "commission_percentage"=>0.2489,
-            # "is_trial_conversion"=>false, # TODO: do something with this?
           }
 
           payment_processor = pay_customer.owner.payment_processor
-          payment_processor.subscribe(**args) # TODO: with lock?
+          payment_processor.subscribe(**args)
 
           Pay::Revenuecat::Charge.create!(
             processor_id: event["transaction_id"],

--- a/lib/pay/revenuecat/webhooks/renewal.rb
+++ b/lib/pay/revenuecat/webhooks/renewal.rb
@@ -16,7 +16,8 @@ module Pay
             ends_at: Time.at(event["expiration_at_ms"].to_i / 1000)
           }
 
-          pay_subscription.with_lock { pay_subscription.update!(**args) } # locked because Pay does it on Stripe
+          # locked because that's that the Pay gem folks do
+          pay_subscription.with_lock { pay_subscription.update!(**args) }
 
           Pay::Revenuecat::Charge.create!(
             processor_id: event["transaction_id"],
@@ -24,7 +25,7 @@ module Pay
             metadata: event["metadata"],
             customer: Pay::Customer.find_by(
               type: "Pay::Revenuecat::Customer",
-              processor_id: event["app_user_id"] # TODO: should this be
+              processor_id: event["app_user_id"]
             )
           )
         end

--- a/lib/pay/revenuecat/webhooks/renewal.rb
+++ b/lib/pay/revenuecat/webhooks/renewal.rb
@@ -12,9 +12,8 @@ module Pay
           args = {
             current_period_start: Time.at(event["purchased_at_ms"].to_i / 1000),
             current_period_end: Time.at(event["expiration_at_ms"].to_i / 1000),
-            metadata: event["metadata"], # TODO: don't replace the metadata, treat a renewal as a charge?
-            status: :active, # TODO: this is probably the location to set trial_conversion (but should these match the stripe examples?)
-            ends_at: nil
+            status: :active,
+            ends_at: Time.at(event["expiration_at_ms"].to_i / 1000)
           }
 
           pay_subscription.with_lock { pay_subscription.update!(**args) } # locked because Pay does it on Stripe

--- a/test/pay/revenuecat/webhooks/cancellation_test.rb
+++ b/test/pay/revenuecat/webhooks/cancellation_test.rb
@@ -15,7 +15,10 @@ class Pay::Revenuecat::Webhooks::CancellationTest < ActiveSupport::TestCase
       current_period_start: 27.days.ago,
       current_period_end: 1.month.from_now.beginning_of_month,
       status: :active,
-      customer: @pay_customer
+      customer: @pay_customer,
+      data: {
+        store: payload["event"]["store"]
+      }
     )
   end
 
@@ -33,21 +36,25 @@ class Pay::Revenuecat::Webhooks::CancellationTest < ActiveSupport::TestCase
     subscription = create_subscription(payload)
     create_initial_charge(payload, subscription)
 
-    Pay::Revenuecat::Webhooks::Cancellation.new.call(
-      cancellation_params["event"]
-    )
+    assert_no_changes "Pay::Revenuecat::Charge.count" do
+      Pay::Revenuecat::Webhooks::Cancellation.new.call(
+        cancellation_params["event"]
+      )
+    end
 
     subscription.reload
 
-    assert_equal 1, subscription.charges.count
     assert_equal "canceled", subscription.status
     assert_equal Time.at(1_740_141_539), subscription.ends_at
+    assert_equal "UNSUBSCRIBE", subscription.data["cancel_reason"]
+    assert_equal "APP_STORE", subscription.data["store"]
   end
 
   test "iOS cancellation after expiration" do
     payload = initial_purchase_params
     subscription = create_subscription(payload)
     create_initial_charge(payload, subscription)
+    # doesn't expire it
 
     subscription.update!(status: "canceled")
 

--- a/test/pay/revenuecat/webhooks/cancellation_test.rb
+++ b/test/pay/revenuecat/webhooks/cancellation_test.rb
@@ -50,21 +50,6 @@ class Pay::Revenuecat::Webhooks::CancellationTest < ActiveSupport::TestCase
     assert_equal "APP_STORE", subscription.data["store"]
   end
 
-  test "iOS cancellation after expiration" do
-    payload = initial_purchase_params
-    subscription = create_subscription(payload)
-    create_initial_charge(payload, subscription)
-    # doesn't expire it
-
-    subscription.update!(status: "canceled")
-
-    Pay::Revenuecat::Webhooks::Cancellation.new.call(
-      cancellation_params["event"]
-    )
-
-    assert_equal "canceled", subscription.reload.status
-  end
-
   test "android cancellation" do
     payload = android_initial_purchase_params
     subscription = create_subscription(payload)

--- a/test/pay/revenuecat/webhooks/expiration_test.rb
+++ b/test/pay/revenuecat/webhooks/expiration_test.rb
@@ -15,7 +15,10 @@ class Pay::Revenuecat::Webhooks::ExpirationTest < ActiveSupport::TestCase
       current_period_start: 27.days.ago,
       current_period_end: 1.month.from_now.beginning_of_month,
       status: :active,
-      customer: @pay_customer
+      customer: @pay_customer,
+      data: {
+        store: payload["event"]["store"]
+      }
     )
   end
 
@@ -33,6 +36,8 @@ class Pay::Revenuecat::Webhooks::ExpirationTest < ActiveSupport::TestCase
     subscription = create_subscription(payload)
     create_initial_charge(payload, subscription)
 
+    assert_equal "APP_STORE", subscription.data["store"]
+
     Pay::Revenuecat::Webhooks::Expiration.new.call(
       expiration_params["event"]
     )
@@ -41,6 +46,8 @@ class Pay::Revenuecat::Webhooks::ExpirationTest < ActiveSupport::TestCase
 
     assert_equal "canceled", subscription.status
     assert_equal Time.at(1_740_141_539), subscription.ends_at
+    assert_equal "APP_STORE", subscription.data["store"]
+    assert_equal "UNSUBSCRIBE", subscription.data["expiration_reason"]
   end
 
   test "android expiration" do

--- a/test/pay/revenuecat/webhooks/initial_purchase_test.rb
+++ b/test/pay/revenuecat/webhooks/initial_purchase_test.rb
@@ -32,6 +32,10 @@ class Pay::Revenuecat::Webhooks::InitialPurchaseTest < ActiveSupport::TestCase
       initial_purchase_params["store"],
       subscription.data["store"]
     )
+    assert_equal(
+      Time.at(initial_purchase_params["expiration_at_ms"] / 1000),
+      subscription.ends_at
+    )
   end
 
   private

--- a/test/pay/revenuecat/webhooks/initial_purchase_test.rb
+++ b/test/pay/revenuecat/webhooks/initial_purchase_test.rb
@@ -24,6 +24,14 @@ class Pay::Revenuecat::Webhooks::InitialPurchaseTest < ActiveSupport::TestCase
       initial_purchase_params["product_id"],
       subscription.processor_plan
     )
+    assert_equal(
+      initial_purchase_params["metadata"],
+      subscription.metadata
+    )
+    assert_equal(
+      initial_purchase_params["store"],
+      subscription.data["store"]
+    )
   end
 
   private

--- a/test/pay/revenuecat/webhooks/renewal_test.rb
+++ b/test/pay/revenuecat/webhooks/renewal_test.rb
@@ -10,8 +10,8 @@ class Pay::Revenuecat::Webhooks::RenewalTest < ActiveSupport::TestCase
   def create_subscription(payload)
     Pay::Revenuecat::Subscription.create!(
       name: "todo: Figure out what should go here",
-      processor_plan: payload["event"]["product_id"],
-      processor_id: payload["event"]["original_transaction_id"],
+      processor_plan: payload["product_id"],
+      processor_id: payload["original_transaction_id"],
       current_period_start: 27.days.ago,
       current_period_end: 1.month.from_now.beginning_of_month,
       status: :active,
@@ -22,22 +22,32 @@ class Pay::Revenuecat::Webhooks::RenewalTest < ActiveSupport::TestCase
   def create_initial_charge(payload, subscription)
     Pay::Revenuecat::Charge.create!(
       subscription: subscription,
-      processor_id: payload["event"]["transaction_id"],
+      processor_id: payload["transaction_id"],
       amount: 9.99,
       customer: @pay_customer
     )
   end
 
-  test "iOS renewal: changes current_period_end" do
+  test "iOS renewal: updates subscription attributes" do
     payload = initial_purchase_params
     subscription = create_subscription(payload)
     create_initial_charge(payload, subscription)
 
-    assert_changes -> { subscription.reload.current_period_end } do
-      Pay::Revenuecat::Webhooks::Renewal.new.call(
-        renewal_params["event"]
-      )
-    end
+    Pay::Revenuecat::Webhooks::Renewal.new.call(
+      renewal_params
+    )
+
+    subscription.reload
+
+    assert_equal(
+      Time.at(renewal_params["expiration_at_ms"] / 1000),
+      subscription.current_period_end
+    )
+
+    assert_equal(
+      Time.at(renewal_params["expiration_at_ms"] / 1000),
+      subscription.ends_at
+    )
   end
 
   test "iOS renewal: adds a new charge" do
@@ -47,7 +57,7 @@ class Pay::Revenuecat::Webhooks::RenewalTest < ActiveSupport::TestCase
 
     assert_difference "Pay::Charge.count" do
       Pay::Revenuecat::Webhooks::Renewal.new.call(
-        renewal_params["event"]
+        renewal_params
       )
     end
   end
@@ -60,12 +70,12 @@ class Pay::Revenuecat::Webhooks::RenewalTest < ActiveSupport::TestCase
     subscription.update!(status: :cancelled, ends_at: 1.day.ago)
 
     Pay::Revenuecat::Webhooks::Renewal.new.call(
-      renewal_after_cancellation_params["event"]
+      renewal_after_cancellation_params
     )
 
     subscription.reload
     assert_equal "active", subscription.status
-    assert_nil subscription.ends_at
+    assert_equal Time.at(1_740_658_577), subscription.ends_at
     assert_equal Time.at(1_740_658_577), subscription.current_period_end
   end
 
@@ -76,7 +86,7 @@ class Pay::Revenuecat::Webhooks::RenewalTest < ActiveSupport::TestCase
 
     assert_difference "Pay::Charge.count" do
       Pay::Revenuecat::Webhooks::Renewal.new.call(
-        renewal_android_params["event"]
+        renewal_android_params
       )
     end
   end
@@ -104,6 +114,6 @@ class Pay::Revenuecat::Webhooks::RenewalTest < ActiveSupport::TestCase
   end
 
   def parse_fixture(filename)
-    JSON.parse(file_fixture(filename).read)
+    JSON.parse(file_fixture(filename).read)["event"]
   end
 end


### PR DESCRIPTION
This PR is addressing #8 and looking more broadly at which data to store.

We made the decision to simplify what data we're storing, and will add things in as they become relevant.

Some things like trial end dates have had tickets added to handle them properly.

My next step is to start testing this in-place in my existing code base and add more functionality as needed.

Co-Authored-By: @theontoka