### PR TITLE
Make model configurable

### DIFF
--- a/lib/pay/revenuecat.rb
+++ b/lib/pay/revenuecat.rb
@@ -18,6 +18,9 @@ module Pay
       true
     end
 
+    mattr_accessor :integration_model_klass
+    @@integration_model_klass = "User"
+
     def self.configure_webhooks
       Pay::Webhooks.configure do |events|
         events.subscribe "revenuecat.INITIAL_PURCHASE", Pay::Revenuecat::Webhooks::Renewal.new

--- a/lib/pay/revenuecat/webhooks/renewal.rb
+++ b/lib/pay/revenuecat/webhooks/renewal.rb
@@ -33,7 +33,7 @@ module Pay
           }
 
           if pay_customer.subscriptions.empty?
-            pay_customer.subscribe(**args)
+            pay_subscription = pay_customer.subscribe(**args)
           else
             pay_subscription = Pay::Subscription.find_by_processor_and_id(
               :revenuecat,
@@ -57,7 +57,8 @@ module Pay
             processor_id: event["transaction_id"],
             amount: (event["price_in_purchased_currency"] * 100).to_i,
             metadata: event["metadata"],
-            customer: pay_customer
+            customer: pay_customer,
+            subscription: pay_subscription
           )
         end
       end

--- a/lib/pay/revenuecat/webhooks/renewal.rb
+++ b/lib/pay/revenuecat/webhooks/renewal.rb
@@ -5,7 +5,9 @@ module Pay
     module Webhooks
       class Renewal
         def call(event)
-          pay_customer = User.find(
+          klass = Pay::Revenuecat.integration_model_klass.constantize
+
+          pay_customer = klass.find(
             event["app_user_id"]
           ).payment_processor
 

--- a/test/dummy/app/models/account.rb
+++ b/test/dummy/app/models/account.rb
@@ -1,0 +1,3 @@
+class Account < ApplicationRecord
+  pay_customer default_payment_processor: :revenuecat
+end

--- a/test/dummy/db/migrate/20250407102418_create_accounts.rb
+++ b/test/dummy/db/migrate/20250407102418_create_accounts.rb
@@ -1,0 +1,9 @@
+class CreateAccounts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :accounts do |t|
+      t.string :email
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/migrate/20250407102418_create_accounts.rb
+++ b/test/dummy/db/migrate/20250407102418_create_accounts.rb
@@ -2,6 +2,7 @@ class CreateAccounts < ActiveRecord::Migration[8.0]
   def change
     create_table :accounts do |t|
       t.string :email
+      t.string :account_name
 
       t.timestamps
     end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -13,6 +13,7 @@
 ActiveRecord::Schema[8.0].define(version: 2025_04_07_102418) do
   create_table "accounts", force: :cascade do |t|
     t.string "email"
+    t.string "account_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_28_150903) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_07_102418) do
+  create_table "accounts", force: :cascade do |t|
+    t.string "email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "pay_charges", force: :cascade do |t|
     t.bigint "customer_id", null: false
     t.bigint "subscription_id"

--- a/test/fixtures/accounts.yml
+++ b/test/fixtures/accounts.yml
@@ -1,3 +1,3 @@
 revenuecat:
   email: revenue_cat@example.com
-  account_name: Reveue Cat Account LTD
+  account_name: Revenue Cat Account LTD

--- a/test/fixtures/accounts.yml
+++ b/test/fixtures/accounts.yml
@@ -1,0 +1,3 @@
+revenuecat:
+  email: revenue_cat@example.com
+  account_name: Reveue Cat Account LTD

--- a/test/fixtures/pay/customers.yml
+++ b/test/fixtures/pay/customers.yml
@@ -4,3 +4,10 @@ revenuecat:
   processor: revenuecat
   processor_id: 0e000000-0000-000a-b000-0000000c0dcd
   default: true
+
+revenuecat_account:
+  type: Pay::Revenuecat::Customer
+  owner: revenuecat (Account)
+  processor: revenuecat
+  processor_id: 42
+  default: false

--- a/test/pay/pay_integration_klass_test.rb
+++ b/test/pay/pay_integration_klass_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Pay::PayIntegrationKlassTest < ActiveSupport::TestCase
+  def setup
+    ::Pay::Revenuecat.integration_model_klass = "Account"
+
+    @pay_customer = pay_customers(:revenuecat_account)
+    @owner = @pay_customer.owner
+  end
+
+  test "INITIAL_PURCHASE -> webhook uses correct klass" do
+    Pay::Revenuecat::Webhooks::Renewal.new.call(
+      initial_purchase_params
+    )
+
+    assert_equal(
+      accounts(:revenuecat),
+      Pay::Revenuecat::Subscription.sole.customer.owner
+    )
+  end
+
+  test "RENEWAL -> webhook uses correct klass" do
+    payload = initial_purchase_params
+    subscription = create_subscription(payload)
+
+    create_initial_charge(payload, subscription)
+
+    Pay::Revenuecat::Webhooks::Renewal.new.call(
+      renewal_params
+    )
+
+    subscription.reload
+
+    assert_equal accounts(:revenuecat), subscription.charges.last.customer.owner
+  end
+
+  test "CANCELLATION -> webhook uses correct klass" do
+    payload = initial_purchase_params
+    subscription = create_subscription(payload)
+
+    create_initial_charge(payload, subscription)
+
+    Pay::Revenuecat::Webhooks::Cancellation.new.call(
+      cancellation_params
+    )
+
+    subscription.reload
+
+    assert_equal "canceled", subscription.status
+  end
+
+  test "EXPIRATION -> webhook uses correct klass" do
+    payload = initial_purchase_params
+    subscription = create_subscription(payload)
+
+    create_initial_charge(payload, subscription)
+
+    Pay::Revenuecat::Webhooks::Expiration.new.call(
+      expiration_params
+    )
+
+    subscription.reload
+
+    assert_equal "canceled", subscription.status
+  end
+end

--- a/test/pay/revenuecat/webhooks/cancellation_test.rb
+++ b/test/pay/revenuecat/webhooks/cancellation_test.rb
@@ -6,30 +6,7 @@ class Pay::Revenuecat::Webhooks::CancellationTest < ActiveSupport::TestCase
   def setup
     Pay::Revenuecat.integration_model_klass = "User"
     @pay_customer = pay_customers(:revenuecat)
-  end
-
-  def create_subscription(payload)
-    Pay::Revenuecat::Subscription.create!(
-      name: "todo: Figure out what should go here",
-      processor_plan: payload["event"]["product_id"],
-      processor_id: payload["event"]["original_transaction_id"],
-      current_period_start: 27.days.ago,
-      current_period_end: 1.month.from_now.beginning_of_month,
-      status: :active,
-      customer: @pay_customer,
-      data: {
-        store: payload["event"]["store"]
-      }
-    )
-  end
-
-  def create_initial_charge(payload, subscription)
-    Pay::Revenuecat::Charge.create!(
-      subscription: subscription,
-      processor_id: payload["event"]["transaction_id"],
-      amount: 9.99,
-      customer: @pay_customer
-    )
+    @owner = @pay_customer.owner
   end
 
   test "iOS cancellation" do
@@ -39,7 +16,7 @@ class Pay::Revenuecat::Webhooks::CancellationTest < ActiveSupport::TestCase
 
     assert_no_changes "Pay::Revenuecat::Charge.count" do
       Pay::Revenuecat::Webhooks::Cancellation.new.call(
-        cancellation_params["event"]
+        cancellation_params
       )
     end
 
@@ -57,7 +34,7 @@ class Pay::Revenuecat::Webhooks::CancellationTest < ActiveSupport::TestCase
     create_initial_charge(payload, subscription)
 
     Pay::Revenuecat::Webhooks::Cancellation.new.call(
-      android_cancellation_params["event"]
+      android_cancellation_params
     )
 
     subscription.reload

--- a/test/pay/revenuecat/webhooks/cancellation_test.rb
+++ b/test/pay/revenuecat/webhooks/cancellation_test.rb
@@ -4,6 +4,7 @@ require "test_helper"
 
 class Pay::Revenuecat::Webhooks::CancellationTest < ActiveSupport::TestCase
   def setup
+    Pay::Revenuecat.integration_model_klass = "User"
     @pay_customer = pay_customers(:revenuecat)
   end
 

--- a/test/pay/revenuecat/webhooks/cancellation_test.rb
+++ b/test/pay/revenuecat/webhooks/cancellation_test.rb
@@ -65,26 +65,4 @@ class Pay::Revenuecat::Webhooks::CancellationTest < ActiveSupport::TestCase
     assert_equal "canceled", subscription.status
     assert_equal Time.at(1_740_571_667), subscription.ends_at
   end
-
-  private
-
-  def initial_purchase_params
-    parse_fixture("initial_purchase.json")
-  end
-
-  def cancellation_params
-    parse_fixture("cancellation.json")
-  end
-
-  def android_cancellation_params
-    parse_fixture("cancellation_android.json")
-  end
-
-  def android_initial_purchase_params
-    parse_fixture("initial_purchase_android_monthly.json")
-  end
-
-  def parse_fixture(filename)
-    JSON.parse(file_fixture(filename).read)
-  end
 end

--- a/test/pay/revenuecat/webhooks/expiration_test.rb
+++ b/test/pay/revenuecat/webhooks/expiration_test.rb
@@ -65,26 +65,4 @@ class Pay::Revenuecat::Webhooks::ExpirationTest < ActiveSupport::TestCase
     assert_equal "canceled", subscription.status
     assert_equal Time.at(1_740_571_667), subscription.ends_at
   end
-
-  private
-
-  def initial_purchase_params
-    parse_fixture("initial_purchase.json")
-  end
-
-  def expiration_params
-    parse_fixture("expiration.json")
-  end
-
-  def android_expiration_params
-    parse_fixture("expiration_android_monthly.json")
-  end
-
-  def android_initial_purchase_params
-    parse_fixture("initial_purchase_android_monthly.json")
-  end
-
-  def parse_fixture(filename)
-    JSON.parse(file_fixture(filename).read)
-  end
 end

--- a/test/pay/revenuecat/webhooks/expiration_test.rb
+++ b/test/pay/revenuecat/webhooks/expiration_test.rb
@@ -4,6 +4,8 @@ require "test_helper"
 
 class Pay::Revenuecat::Webhooks::ExpirationTest < ActiveSupport::TestCase
   def setup
+    Pay::Revenuecat.integration_model_klass = "User"
+
     @pay_customer = pay_customers(:revenuecat)
   end
 

--- a/test/pay/revenuecat/webhooks/renewal_test.rb
+++ b/test/pay/revenuecat/webhooks/renewal_test.rb
@@ -4,6 +4,7 @@ require "test_helper"
 
 class Pay::Revenuecat::Webhooks::RenewalTest < ActiveSupport::TestCase
   def setup
+    Pay::Revenuecat.integration_model_klass = "User"
     @pay_customer = pay_customers(:revenuecat)
     @owner = @pay_customer.owner
   end

--- a/test/pay/revenuecat_test.rb
+++ b/test/pay/revenuecat_test.rb
@@ -7,11 +7,8 @@ class Pay::RevenuecatTest < ActiveSupport::TestCase
     refute_nil ::Pay::Revenuecat::VERSION
   end
 
-  test "#intgration_model_klass is 'User'" do
-    assert_equal "User", ::Pay::Revenuecat.integration_model_klass
-  end
-
-  test "#integration_model_klass can be set to a different model" do
+  test "#integration_model_klass can be set and read" do
     assert_equal "Foo", ::Pay::Revenuecat.integration_model_klass = "Foo"
+    assert_equal "Foo", ::Pay::Revenuecat.integration_model_klass
   end
 end

--- a/test/pay/revenuecat_test.rb
+++ b/test/pay/revenuecat_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Pay::RevenuecatTest < ActiveSupport::TestCase
+  def test_that_it_has_a_version_number
+    refute_nil ::Pay::Revenuecat::VERSION
+  end
+
+  test "#intgration_model_klass is 'User'" do
+    assert_equal "User", ::Pay::Revenuecat.integration_model_klass
+  end
+
+  test "#integration_model_klass can be set to a different model" do
+    assert_equal "Foo", ::Pay::Revenuecat.integration_model_klass = "Foo"
+  end
+end

--- a/test/pay/test_revenuecat.rb
+++ b/test/pay/test_revenuecat.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require "test_helper"
-
-class Pay::TestRevenuecat < Minitest::Test
-  def test_that_it_has_a_version_number
-    refute_nil ::Pay::Revenuecat::VERSION
-  end
-end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -53,6 +53,22 @@ def android_initial_purchase_params
   parse_fixture("initial_purchase_android_monthly.json")
 end
 
+def cancellation_params
+  parse_fixture("cancellation.json")
+end
+
+def android_cancellation_params
+  parse_fixture("cancellation_android.json")
+end
+
+def expiration_params
+  parse_fixture("expiration.json")
+end
+
+def android_expiration_params
+  parse_fixture("expiration_android_monthly.json")
+end
+
 def parse_fixture(filename)
   JSON.parse(file_fixture(filename).read)["event"].merge({
     "app_user_id" => @owner.id,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -84,7 +84,10 @@ def create_subscription(payload)
     current_period_start: 27.days.ago,
     current_period_end: 1.month.from_now.beginning_of_month,
     status: :active,
-    customer: @pay_customer
+    customer: @pay_customer,
+    data: {
+      store: payload["store"]
+    }
   )
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,3 +32,51 @@ elsif ActiveSupport::TestCase.respond_to?(:fixture_path=)
 end
 ActiveSupport::TestCase.file_fixture_path = File.expand_path("fixtures/files", __dir__)
 ActiveSupport::TestCase.fixtures :all
+
+def initial_purchase_params
+  parse_fixture("initial_purchase.json")
+end
+
+def renewal_params
+  parse_fixture("renewal.json")
+end
+
+def renewal_after_cancellation_params
+  parse_fixture("renewal_after_expiration_without_initial_purchase.json")
+end
+
+def renewal_android_params
+  parse_fixture("renewal_android_monthly.json")
+end
+
+def android_initial_purchase_params
+  parse_fixture("initial_purchase_android_monthly.json")
+end
+
+def parse_fixture(filename)
+  JSON.parse(file_fixture(filename).read)["event"].merge({
+    "app_user_id" => @owner.id,
+    "original_app_user_id" => @owner.id
+  })
+end
+
+def create_subscription(payload)
+  Pay::Revenuecat::Subscription.create!(
+    name: "todo: Figure out what should go here",
+    processor_plan: payload["product_id"],
+    processor_id: payload["original_transaction_id"],
+    current_period_start: 27.days.ago,
+    current_period_end: 1.month.from_now.beginning_of_month,
+    status: :active,
+    customer: @pay_customer
+  )
+end
+
+def create_initial_charge(payload, subscription)
+  Pay::Revenuecat::Charge.create!(
+    subscription: subscription,
+    processor_id: payload["transaction_id"],
+    amount: 9.99,
+    customer: @pay_customer
+  )
+end


### PR DESCRIPTION
We are making it so you can define which model the gem should look for pay related records on. This is because people can configure the pay gem on whichever model they like, i.e. `User`, `Business`, `Account`, `Dinosaur` 