### PR TITLE
Fix canceled? and clear cancel_reason on renewal

### DIFF
--- a/app/models/pay/revenue_cat/subscription.rb
+++ b/app/models/pay/revenue_cat/subscription.rb
@@ -1,6 +1,8 @@
 module Pay
   module RevenueCat
     class Subscription < Pay::Subscription
+      def canceled? = status == "canceled"
+
       def paused? = status == "paused"
 
       def resumable? = false
@@ -8,7 +10,10 @@ module Pay
       def self.find_or_create_from_event(customer, event)
         existing = customer.subscriptions.find_by(processor_id: event["original_transaction_id"])
         if existing
-          existing.with_lock { existing.update!(**renewal_attributes(event)) }
+          existing.with_lock do
+            data = (existing.data || {}).except("cancel_reason", :cancel_reason)
+            existing.update!(**renewal_attributes(event), data: data)
+          end
           existing
         else
           customer.subscribe(**subscription_attributes(event))

--- a/test/models/pay/revenue_cat/subscription_test.rb
+++ b/test/models/pay/revenue_cat/subscription_test.rb
@@ -26,6 +26,14 @@ class Pay::RevenueCat::SubscriptionTest < ActiveSupport::TestCase
     refute Pay::RevenueCat::Subscription.new(status: :canceled).paused?
   end
 
+  test "#canceled? returns true when status is canceled" do
+    assert Pay::RevenueCat::Subscription.new(status: :canceled).canceled?
+  end
+
+  test "#canceled? returns false when status is active even with ends_at set" do
+    refute Pay::RevenueCat::Subscription.new(status: :active, ends_at: 1.month.from_now).canceled?
+  end
+
   test ".find_or_create_from_event creates subscription when none exists" do
     event = initial_purchase_params
 

--- a/test/pay/revenue_cat/webhooks/renewal_test.rb
+++ b/test/pay/revenue_cat/webhooks/renewal_test.rb
@@ -140,6 +140,26 @@ class Pay::RevenueCat::Webhooks::RenewalTest < ActiveSupport::TestCase
     assert_equal Time.at(1_740_658_577), subscription.current_period_end
   end
 
+  test "RENEWAL -> iOS -> clears cancel_reason from data after reactivation" do
+    payload = initial_purchase_params
+    subscription = create_subscription(payload)
+    create_initial_charge(payload, subscription)
+
+    subscription.update!(
+      status: :cancelled,
+      ends_at: 1.day.ago,
+      data: subscription.data.merge("cancel_reason" => "CUSTOMER_SUPPORT")
+    )
+
+    Pay::RevenueCat::Webhooks::Renewal.new.call(
+      renewal_after_cancellation_params
+    )
+
+    subscription.reload
+    assert_equal "active", subscription.status
+    assert_nil subscription.data["cancel_reason"]
+  end
+
   # we may not get here in real life but what happens with sandbox accounts
   # is if you have already had a subscriotion expire and start a new one
   # revenue_cat send a renewal event. If you're re-seeding your database this


### PR DESCRIPTION
## Summary
- Override `canceled?` in `Pay::RevenueCat::Subscription` to check `status == "canceled"` instead of `ends_at?`. Pay gem's default `canceled?` checks `ends_at?`, but RevenueCat always sets `ends_at` to `expiration_at_ms`, making every active subscription falsely report as canceled.
- Clear `cancel_reason` from the subscription `data` hash when processing a renewal on a previously canceled subscription, matching what the Uncancellation handler already does.

## Test plan
- [x] Added test: `canceled?` returns false for active subscription even with `ends_at` set
- [x] Added test: `canceled?` returns true for canceled subscription
- [x] Added test: renewal clears `cancel_reason` from data after reactivation
- [x] All 66 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)