### PR TITLE
Fix cancellation status and add active? override

### DIFF
--- a/app/models/pay/revenue_cat/subscription.rb
+++ b/app/models/pay/revenue_cat/subscription.rb
@@ -1,6 +1,10 @@
 module Pay
   module RevenueCat
     class Subscription < Pay::Subscription
+      def active? = !ends_at? || ends_at.future?
+
+      def canceled? = status == "canceled"
+
       def paused? = status == "paused"
 
       def resumable? = false
@@ -8,7 +12,10 @@ module Pay
       def self.find_or_create_from_event(customer, event)
         existing = customer.subscriptions.find_by(processor_id: event["original_transaction_id"])
         if existing
-          existing.with_lock { existing.update!(**renewal_attributes(event)) }
+          existing.with_lock do
+            data = (existing.data || {}).except("cancel_reason", :cancel_reason)
+            existing.update!(**renewal_attributes(event), data: data)
+          end
           existing
         else
           customer.subscribe(**subscription_attributes(event))

--- a/lib/pay/revenue_cat/webhooks/cancellation.rb
+++ b/lib/pay/revenue_cat/webhooks/cancellation.rb
@@ -21,7 +21,7 @@ module Pay
 
             pay_subscription.with_lock do
               pay_subscription.update!(
-                status: (ends_at.future? ? :active : :canceled),
+                status: :canceled,
                 ends_at: ends_at,
                 data: data
               )

--- a/test/models/pay/revenue_cat/subscription_test.rb
+++ b/test/models/pay/revenue_cat/subscription_test.rb
@@ -26,6 +26,29 @@ class Pay::RevenueCat::SubscriptionTest < ActiveSupport::TestCase
     refute Pay::RevenueCat::Subscription.new(status: :canceled).paused?
   end
 
+  test "#canceled? returns true when status is canceled" do
+    assert Pay::RevenueCat::Subscription.new(status: :canceled).canceled?
+  end
+
+  test "#canceled? returns false when status is active even with ends_at set" do
+    refute Pay::RevenueCat::Subscription.new(status: :active, ends_at: 1.month.from_now).canceled?
+  end
+
+  test "#active? returns true for subscription with future ends_at" do
+    subscription = Pay::RevenueCat::Subscription.new(status: :active, ends_at: 1.month.from_now)
+    assert subscription.active?
+  end
+
+  test "#active? returns true for subscription with nil ends_at" do
+    subscription = Pay::RevenueCat::Subscription.new(status: :active, ends_at: nil)
+    assert subscription.active?
+  end
+
+  test "#active? returns false for subscription with past ends_at" do
+    subscription = Pay::RevenueCat::Subscription.new(status: :canceled, ends_at: 1.day.ago)
+    refute subscription.active?
+  end
+
   test ".find_or_create_from_event creates subscription when none exists" do
     event = initial_purchase_params
 

--- a/test/pay/revenue_cat/webhooks/cancellation_test.rb
+++ b/test/pay/revenue_cat/webhooks/cancellation_test.rb
@@ -44,6 +44,24 @@ class Pay::RevenueCat::Webhooks::CancellationTest < ActiveSupport::TestCase
     assert_equal Time.at(1_740_571_667), subscription.ends_at
   end
 
+  test "cancellation with future expiration sets canceled status but remains active" do
+    payload = initial_purchase_params
+    subscription = create_subscription(payload)
+    create_initial_charge(payload, subscription)
+
+    future_expiration = (Time.now.to_i + 86400) * 1000 # 1 day from now
+    params = cancellation_params.merge("expiration_at_ms" => future_expiration)
+
+    Pay::RevenueCat::Webhooks::Cancellation.new.call(params)
+
+    subscription.reload
+
+    assert_equal "canceled", subscription.status
+    assert subscription.canceled?
+    assert subscription.active?
+    assert subscription.on_grace_period?
+  end
+
   test "runs within a transaction" do
     payload = initial_purchase_params
     subscription = create_subscription(payload)

--- a/test/pay/revenue_cat/webhooks/renewal_test.rb
+++ b/test/pay/revenue_cat/webhooks/renewal_test.rb
@@ -140,6 +140,26 @@ class Pay::RevenueCat::Webhooks::RenewalTest < ActiveSupport::TestCase
     assert_equal Time.at(1_740_658_577), subscription.current_period_end
   end
 
+  test "RENEWAL -> iOS -> clears cancel_reason from data after reactivation" do
+    payload = initial_purchase_params
+    subscription = create_subscription(payload)
+    create_initial_charge(payload, subscription)
+
+    subscription.update!(
+      status: :cancelled,
+      ends_at: 1.day.ago,
+      data: subscription.data.merge("cancel_reason" => "CUSTOMER_SUPPORT")
+    )
+
+    Pay::RevenueCat::Webhooks::Renewal.new.call(
+      renewal_after_cancellation_params
+    )
+
+    subscription.reload
+    assert_equal "active", subscription.status
+    assert_nil subscription.data["cancel_reason"]
+  end
+
   # we may not get here in real life but what happens with sandbox accounts
   # is if you have already had a subscriotion expire and start a new one
   # revenue_cat send a renewal event. If you're re-seeding your database this


### PR DESCRIPTION
## Summary
- Always set `status: :canceled` on cancellation events instead of conditionally choosing active/canceled based on expiration date
- Add `active?` override to `Subscription` so canceled subscriptions on grace period still grant access (`!ends_at? || ends_at.future?`)
- Add `canceled?` override to `Subscription`
- Clear `cancel_reason` from data on renewal reactivation

## Test plan
- [x] All 70 tests pass
- [ ] Verify `canceled?` returns true immediately after cancellation (even with future expiration)
- [ ] Verify `active?` returns true for canceled subscription with future `ends_at` (grace period)
- [ ] Verify `on_grace_period?` works correctly for grace period subscriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)